### PR TITLE
Update mocha peer dep to include 9.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "3.3.3"
   },
   "peerDependencies": {
-    "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X"
+    "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X"
   },
   "optionalDependencies": {
     "tsconfig-paths": "^3.5.0"


### PR DESCRIPTION
This should hopefully address #65.

Also, this or another change can update the `mocha` and `@types/mocha` dev dependencies, if needed.