### PR TITLE
Bump tsconfig-paths and place in peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,15 @@
 [![Codeship Status for piotrwitek/ts-mocha](https://app.codeship.com/projects/cb8cc460-1719-0137-28fd-3a09a0997096/status?branch=master)](https://app.codeship.com/projects/328034)
 [![Greenkeeper badge](https://badges.greenkeeper.io/piotrwitek/ts-mocha.svg)](https://greenkeeper.io/)
 
-> `ts-mocha` is a wrapper on top of `mocha` to allow running tests written in TypeScript without setting up a complicated setup in your project, it just works.
-
-> All `mocha` features are available without any limitation because `ts-mocha` is passing all the params to original `mocha` behind the scenes.
+> `ts-mocha` is a streamlined process wrapper for mocha that simplifies running tests written in TypeScript. It automatically handles the necessary configuration and adds custom arguments, saving you from the hassle of managing a complex test setup in your project.
 
 ## Why?
 
-To setup Mocha with TypeScript you need to figure out how to set it up together, it's not an easy task and require some time and effort to setup correctly. Moreover this setup will stop working whenever `mocha` or `ts-node` introduce breaking changes, so you'll have to fix it and waste your time again.
+Setting up Mocha to work with TypeScript can be challenging and time-consuming. It requires careful configuration to ensure compatibility between the two tools. Additionally, breaking changes in mocha or ts-node can disrupt your setup, forcing you to spend valuable time troubleshooting and fixing it.
 
-This package handles all that concerns for you and let you use `ts-mocha` in the same way as a regular mocha while supporting TypeScript.
+`ts-mocha` eliminates these headaches by handling all the configuration for you. It allows you to run tests in TypeScript just as easily as you would with regular Mocha and JavaScript, without worrying about the underlying setup.
 
-Also we added some useful options to make your life easier specifically for TypeScript projects, you can find them below.
-
-## How?
-
-TS-Mocha has one only dependency - ts-node, which is used as a TypeScript runtime to execute tests that can import and run imported TypeScript source files as well. It is a thin wrapper that run node process with mocha and set up ts-node environment to handle `.ts` and `.tsx` files. To speed up TypeScript tests execution type-checking is disabled, using only transpile mode.
-
-> **NOTE**: This package does not include Mocha - Mocha is set as peer dependency, so I don't lock the consumer to a specific Mocha version and I don't have to update this package when Mocha is updated.
-
-> **PRO TIP**: To make your developer experience better I recommend to run type-checking in a separate process by starting TSC compiler (preferably in watch mode) in you terminal with --noEmit and --project flags.
+On top of that, we’ve included several useful options tailored specifically for TypeScript projects to make your development experience even smoother. Check them out below!
 
 ## Installation
 
@@ -33,11 +23,14 @@ TS-Mocha has one only dependency - ts-node, which is used as a TypeScript runtim
 
 npm i -D ts-mocha
 
-# remember to install required peerDependencies
-npm i -D mocha ts-node
+# and also required peerDependencies
+npm i -D mocha ts-node tsconfig-paths
 
-# install recent Mocha and Expect @types packages for best DX
+# also relevant @types packages for best DX: Mocha and Expect
 npm i -D @types/mocha @types/expect
+
+# there is also an optional peerDependency if you're using it in your project
+npm i -D tsconfig-paths
 ```
 
 ## Usage
@@ -54,13 +47,9 @@ CLI options consist of all the options of regular Mocha plus extra options below
 ts-mocha -p src/tsconfig.json src/**/*.spec.ts
 ```
 
-`--paths` - feature toggle flag to enable [`tsconfig-paths`](https://www.npmjs.com/package/tsconfig-paths) integration [default: false]
+`--paths` - opt-in feature toggle flag to enable [`tsconfig-paths`](https://www.npmjs.com/package/tsconfig-paths) integration [default: false]
 
-> `tsconfig-paths` is an optional dependency, make sure to install it locally in your project
-
-When using [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) via the `paths` compiler option in `tsconfig.json` this library utilizes the [`tsconfig-paths`](https://www.npmjs.com/package/tsconfig-paths) package, allowing for automatic resolution of aliased modules locations during test execution.
-
-Check our test suite for a reference implementation: [Link](./test/paths/tsconfig.json)
+> _For this to work you need to have [`tsconfig-paths`](https://www.npmjs.com/package/tsconfig-paths) package installed in your project_
 
 **Example:**
 
@@ -68,9 +57,13 @@ Check our test suite for a reference implementation: [Link](./test/paths/tsconfi
 ts-mocha --paths -p src/ src/**/*.spec.ts
 ```
 
+_This feature is required if you're using [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) feature in your project (`paths` compiler option in `tsconfig.json`). When enabled with this package it allows for correct module resolution of aliased modules during TypeScript code execution within NodeJS environment._
+
+Check our test suite for a reference implementation: [Link](./test/paths/tsconfig.json)
+
 `--type-check` - feature toggle flag to enable type checking in ts-node [default: false]
 
-By default ts-mocha uses the `--transpile-only` option of ts-node to make tests run faster. Use the `--type-check` option to enable type checking in ts-node.
+By default `ts-mocha` use the `--transpile-only` option of ts-node to make tests run significantly faster. If you want to run your tests slower but with type-checking you can use the `--type-check` option to enable that.
 
 **Example:**
 
@@ -80,7 +73,7 @@ ts-mocha --type-check -p src/ src/**/*.spec.ts
 
 ### Watch Mode
 
-If you want your tests to be automatically rerun when your code changes, add both the `-w` flag and the `--watch-files` flag telling it to watch for typescript files.
+If you want your tests to be automatically rerun when your code changes, add both the `-w` flag and the `--watch-files` flag telling it to watch for specified TypeScript files.
 
 **Example:**
 
@@ -118,3 +111,11 @@ mocha.run((failures) => {
   });
 });
 ```
+
+## How it works?
+
+`ts-mocha` relies on a single dependency: ts-node. This TypeScript runtime enables the execution of tests that can import and run TypeScript source files directly.
+
+As a lightweight wrapper, ts-mocha launches a Node process with Mocha and configures the ts-node environment to handle .ts and .tsx files seamlessly. To optimize performance, type-checking is disabled by default, and ts-node operates in transpile-only mode for faster test execution.
+
+> **NOTE**: This package does not include Mocha - Mocha is set as peer dependency, so I don't lock the consumer to a specific Mocha version and I don't have to update this package when Mocha is updated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,15 @@
       "engines": {
         "node": ">= 6.X.X"
       },
-      "optionalDependencies": {
-        "tsconfig-paths": "^4.1.2"
-      },
       "peerDependencies": {
         "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X || ^11.X.X",
-        "ts-node": "^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X"
+        "ts-node": "^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X",
+        "tsconfig-paths": "^4.X.X"
+      },
+      "peerDependenciesMeta": {
+        "tsconfig-paths": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1095,6 +1098,7 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "optional": true,
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -1667,6 +1671,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -1776,6 +1781,7 @@
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,13 @@
     "typescript": "3.3.3"
   },
   "peerDependencies": {
-    "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X"
+    "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X",
+    "tsconfig-paths": "^4.1.1"
   },
-  "optionalDependencies": {
-    "tsconfig-paths": "^3.5.0"
+  "peerDependenciesMeta": {
+    "tsconfig-paths": {
+      "optional": true
+    }
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X || ^11.X.X",
     "ts-node": "^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X",
-    "tsconfig-paths": "^4.1.1"
+    "tsconfig-paths": "^4.X.X"
   },
   "peerDependenciesMeta": {
     "tsconfig-paths": {


### PR DESCRIPTION
When running unit tests in my application it takes over 3 minutes to begin running the tests because of a complex interaction between the dated version of `tsconfig-paths` requested by `ts-mocha` and our `react` and `material-ui` heavy stack. The older version of `tsconfig-paths` has a very inefficient loading mechanism that results in hundreds of thousands of additional file system reads similar to this, taken using `strace`:

```
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.js", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000035>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.json", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000034>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.node", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000035>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.ts", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000035>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.tsx", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000107>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.css", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000088>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.scss", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000086>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.sass", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000073>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.pcss", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000083>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.stylus", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000071>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.styl", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.003708>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.less", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000071>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.sss", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000065>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.gif", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000071>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.jpeg", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000076>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.jpg", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000197>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.png", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000100>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.svg", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000111>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.mp4", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000069>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.webm", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000077>
[pid  2047] statx(AT_FDCWD, "/app/@mui/utils/index.ogv", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffddce5bb50) = -1 ENOENT (No such file or directory) <0.000115>
```

For every file `tsconfig-paths` loads, it's attempting to read it with 21 different extensions multiplied by the total number of files in the project. In my project this is 182,000 file reads. When I update to a newer version of `tsconfig-paths` this changes to 3,000 file reads. This is due to another package increasing the possible extensions in `require.extensions`. Looking at your readme it seems like your intent was to make this an optional dependency, such that if a user wants it, they should include it. In this case I believe the proper mechanism is actually a `peerDependency` with it being marked as `optional` via `peerDependenciesMeta` (https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependenciesmeta). This means it will not be downloaded unless the user adds it to their `package.json`, and then it will use whatever version they download but will warn if they aren't using `^4.1.1`.