### PR TITLE
feat: add github action ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ jobs:
     strategy:
       matrix:
         mocha-version: [3, 4, 5, 6, 7, 8, 9, 10]
+        node-version: [14, 16, 18, 19]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: ${{ matrix.node-version}}
       - name: install dependencies
         run: |
           npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: "Continuous Integration"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  continuous-integration:
+    name: continuous-integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        mocha-version: [3, 4, 5, 6, 7, 8, 9, 10]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: install dependencies
+        run: |
+          npm ci
+          npm i mocha@${{ matrix.mocha-version}}
+      - name: test
+        run: |
+          npm test


### PR DESCRIPTION
Add GitHub Action CI workflow. 

This workflow will run with a matrix strategy meaning that we will test with every `mocha` version the library supports according to the `peerDependencies` specified in the package.json and every supported NodeJS version according to the [Release Schedule](https://github.com/nodejs/release#release-schedule.) 

The workflow will run: 
- when a commit is pushed to the `master` branch
- and when a commit is pushed in a PR and it will block the PR from being merged in case the workflow fails.