### PR TITLE
Support mocha's --posix-exit-codes option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ CLI options consist of all the options of regular Mocha plus extra options below
 
 `-p, --project <value>` - relative or absolute path to a `tsconfig.json` file (equivalent of `tsc -p <value>`) [default: "./tsconfig.json"]
 
-`--posix-exit-codes` - exit with non-zero POSIX code if interrupted with fatal signal
-
 **Example:**
 
 ```bash
@@ -70,6 +68,8 @@ By default `ts-mocha` use the `--transpile-only` option of ts-node to make tests
 ```bash
 ts-mocha --type-check -p src/ src/**/*.spec.ts
 ```
+
+`--posix-exit-codes` - exit with non-zero POSIX code if interrupted with fatal signal
 
 ### Watch Mode
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ CLI options consist of all the options of regular Mocha plus extra options below
 
 `-p, --project <value>` - relative or absolute path to a `tsconfig.json` file (equivalent of `tsc -p <value>`) [default: "./tsconfig.json"]
 
+`--posix-exit-codes` - exit with non-zero POSIX code if interrupted with fatal signal
+
 **Example:**
 
 ```bash

--- a/bin/ts-mocha
+++ b/bin/ts-mocha
@@ -32,7 +32,7 @@ process.argv.slice(2).forEach(function (arg, idx, arr) {
 
     case "--posix-exit-codes":
       process.env.POSIX_EXIT_CODES = true;
-      mochaArgs.push(arg); // add when supported by mocha
+      mochaArgs.push(arg);
       break;
 
     default:

--- a/bin/ts-mocha
+++ b/bin/ts-mocha
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var os = require('os');
 var path = require('path');
 var spawn = require('child_process').spawn;
 
@@ -29,6 +30,11 @@ process.argv.slice(2).forEach(function (arg, idx, arr) {
       process.env.TS_TYPE_CHECK = true;
       break;
 
+    case "--posix-exit-codes":
+      process.env.POSIX_EXIT_CODES = true;
+      mochaArgs.push(arg); // add when supported by mocha
+      break;
+
     default:
       // pass unrecognized args to mocha
       mochaArgs.push(arg);
@@ -40,9 +46,17 @@ var mocha = spawn(process.execPath, mochaArgs, {
   stdio: "inherit",
 });
 mocha.on('exit', function (code, signal) {
+  console.warn(`ts-mocha saw mocha exit with code ${code} and signal ${signal}`);
   process.on('exit', function () {
     if (signal) {
-      process.kill(process.pid, signal);
+      if(process.env.POSIX_EXIT_CODES == 'true') {
+        console.warn(`ts-mocha exiting with code ${128 + os.constants.signals[signal]}`)
+        process.exitCode = 128 +  os.constants.signals[signal];
+        process.exit(process.exitCode);
+      } else {
+        console.warn(`ts-mocha killing process with ${signal}; process.exitCode ${process.exitCode}`);
+        process.kill(process.pid, signal);
+      }
     } else {
       process.exit(code);
     }


### PR DESCRIPTION
This PR adds support for mocha's new --posix-exit-codes command line option. When this option is given, mocha will exit using standard posix exit codes instead of using he number of failed tests as the exit code. This avoids situations like out-of-memory errors causing CICD pipelines that use ts-mocha from failing silently.